### PR TITLE
feat: Test supervisor types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export const TaskStatus = z.enum([
   "in-progress",
   "blocked",
   "review",
+  "needs-review",
   "done",
   "failed",
 ]);
@@ -174,8 +175,24 @@ export const ForgeConfigSchema = z.object({
     dir: z.string().default(".forge"),
     heartbeat_interval: z.number().default(60),
   }).default({}),
+  supervisor: z.object({
+    supervisor_enabled: z.boolean().default(true),
+    supervisor_model: z.string().default("sonnet"),
+    supervisor_criteria: z.array(z.string()).default([]),
+    max_supervisor_rounds: z.number().default(2),
+  }).default({}),
 });
 export type ForgeConfig = z.infer<typeof ForgeConfigSchema>;
+
+// ─── Supervisor Finding ──────────────────────────────────────────
+
+export interface SupervisorFinding {
+  task_id: string;
+  round: number;
+  verdict: "pass" | "fail" | "needs-revision";
+  findings: string[];
+  feedback: string;
+}
 
 // ─── Worker Handle ───────────────────────────────────────────────
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { TaskStatus, ForgeConfigSchema, type SupervisorFinding } from "../src/types.js";
+
+describe("TaskStatus", () => {
+  it("includes needs-review status", () => {
+    const result = TaskStatus.safeParse("needs-review");
+    expect(result.success).toBe(true);
+  });
+
+  it("includes all original statuses", () => {
+    for (const s of ["todo", "in-progress", "blocked", "review", "done", "failed"]) {
+      expect(TaskStatus.safeParse(s).success).toBe(true);
+    }
+  });
+
+  it("rejects unknown status", () => {
+    expect(TaskStatus.safeParse("unknown").success).toBe(false);
+  });
+});
+
+describe("ForgeConfigSchema supervisor section", () => {
+  const minimalConfig = {
+    github: { org: "test-org" },
+    hosts: {},
+    agents: {},
+    review: {},
+    notifications: {},
+    state: {},
+  };
+
+  it("applies default supervisor_enabled true", () => {
+    const result = ForgeConfigSchema.parse(minimalConfig);
+    expect(result.supervisor.supervisor_enabled).toBe(true);
+  });
+
+  it("applies default supervisor_model sonnet", () => {
+    const result = ForgeConfigSchema.parse(minimalConfig);
+    expect(result.supervisor.supervisor_model).toBe("sonnet");
+  });
+
+  it("applies default supervisor_criteria as empty array", () => {
+    const result = ForgeConfigSchema.parse(minimalConfig);
+    expect(result.supervisor.supervisor_criteria).toEqual([]);
+  });
+
+  it("applies default max_supervisor_rounds 2", () => {
+    const result = ForgeConfigSchema.parse(minimalConfig);
+    expect(result.supervisor.max_supervisor_rounds).toBe(2);
+  });
+
+  it("accepts custom supervisor values", () => {
+    const result = ForgeConfigSchema.parse({
+      ...minimalConfig,
+      supervisor: {
+        supervisor_enabled: false,
+        supervisor_model: "opus",
+        supervisor_criteria: ["no secrets", "tests pass"],
+        max_supervisor_rounds: 3,
+      },
+    });
+    expect(result.supervisor.supervisor_enabled).toBe(false);
+    expect(result.supervisor.supervisor_model).toBe("opus");
+    expect(result.supervisor.supervisor_criteria).toEqual(["no secrets", "tests pass"]);
+    expect(result.supervisor.max_supervisor_rounds).toBe(3);
+  });
+});
+
+describe("SupervisorFinding", () => {
+  it("can be constructed with required fields", () => {
+    const finding: SupervisorFinding = {
+      task_id: "task-1",
+      round: 1,
+      verdict: "pass",
+      findings: ["All tests pass"],
+      feedback: "Good work.",
+    };
+    expect(finding.task_id).toBe("task-1");
+    expect(finding.round).toBe(1);
+    expect(finding.verdict).toBe("pass");
+    expect(finding.findings).toHaveLength(1);
+    expect(finding.feedback).toBe("Good work.");
+  });
+
+  it("supports all verdict values", () => {
+    const verdicts: SupervisorFinding["verdict"][] = ["pass", "fail", "needs-revision"];
+    for (const verdict of verdicts) {
+      const finding: SupervisorFinding = {
+        task_id: "task-1",
+        round: 1,
+        verdict,
+        findings: [],
+        feedback: "",
+      };
+      expect(finding.verdict).toBe(verdict);
+    }
+  });
+});


### PR DESCRIPTION
Closes #48

## Summary
- Adds `tests/types.test.ts` with 10 unit tests for supervisor types
- Validates `ForgeConfigSchema` supervisor section defaults parse correctly
- Verifies `SupervisorFinding` interface accepts all valid verdict values
- Confirms `needs-review` is a valid `TaskStatus`

## Tests Added
- `TaskStatus`: includes needs-review, all original statuses, rejects unknown
- `ForgeConfigSchema supervisor`: defaults for enabled, model, criteria, max_rounds; accepts custom values
- `SupervisorFinding`: required fields, all verdict values (pass/fail/needs-revision)

## Test Results
All 33 tests pass (3 test files)